### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
 
 # Setup
 title:            Hyde


### PR DESCRIPTION
Deleted Permalink option as described here to make theme compatible with current version of Github - https://help.github.com/articles/page-build-failed-relative-permalinks-configured/